### PR TITLE
make importable

### DIFF
--- a/pyinteraph/main.py
+++ b/pyinteraph/main.py
@@ -35,6 +35,16 @@ from libinteract import libinteract as li
 
 def main(argsv=None):
 
+    # Override exit function to only print error WHEN "main" is called 
+    # interactively, and avoid exiting the Python interpreter
+    if __name__ != "__main__":
+        # Annuling the function that prints errors and tracebacks
+        sys.excepthook = lambda type, value, traceback: None
+        # When "exit" is called, instead of exiting the intepreter, a
+        # silent (see: preceding line) exception is raised to simply 
+        # halt the "main" function execution
+        def exit(code): raise
+
 
     ######################### ARGUMENT PARSER #########################
 

--- a/pyinteraph/main.py
+++ b/pyinteraph/main.py
@@ -33,7 +33,7 @@ import MDAnalysis as mda
 import numpy as np
 from libinteract import libinteract as li
 
-def main():
+def main(argsv=None):
 
 
     ######################### ARGUMENT PARSER #########################
@@ -618,7 +618,7 @@ def main():
                         dest = "verbose",
                         help = v_helpstr)
 
-    args = parser.parse_args()
+    args = parser.parse_args(argsv)
 
 
     ########################## LOGGER SETUP ###########################


### PR DESCRIPTION
Added an `argsv` argument to the `main` function with `None` as a default, and passed this `argsv` to the `parser.parse_args(argsv)` function. This way, the `main` function can be imported and a list of arguments passed as if they were those on CLI (e.g., a list with `argsv=["-s", "protein.pdb", "-t", "traj_1.xtc", "-m"]`) to use PyInteraph2 programatically. With `argsv` being `None` as default, it ensures that when PyInteraph2 is called from the CLI the `parser.parse_args` function looks for `sys.argv` as always. See [here](https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.parse_args) how the first argument of `parse_args` is already `None` by default and it makes it use `sys.argv`.